### PR TITLE
Pin conda to previous version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,8 @@ channels:
 dependencies:
   - python
   - mamba
-  - pip>=21.1
+  - conda=22.9
+  - pip>=22.3
   - setuptools_scm
   - toml
 
@@ -36,6 +37,7 @@ dependencies:
   - myst-parser
 
   # Misc
+  - pdbpp
   - pre-commit
   - pytest
   - pytest-cov


### PR DESCRIPTION
Reason: Weird test failures after update to 22.11

Add pdbpp and require recent pip.