### PR TITLE
Use git_remote_url throughout instead of a mix with hand-constructed links.

### DIFF
--- a/docs/source/getting_started/cookiecutter_dialogue.md
+++ b/docs/source/getting_started/cookiecutter_dialogue.md
@@ -44,7 +44,10 @@
    **github_email** -- The email linked to your GitHub account (only relevant for your
    local machine, will be different for coauthors / other group members).
 
-   **git_remote_url** -- Paste your remote URL here if applicable.
+   **git_remote_url** -- Paste your GIT remote URL here if applicable. Must be of the
+   form `https://github.com/<user or organisation name>/<repo name>`. I.e., a
+   `https://`-link and without `.git` at the end. This is required because it will be
+   used in multiple places. Need not be github.
 
    **make_initial_commit** -- Whether we should make the first commit for you.
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,6 +1,7 @@
 """Hooks which are executed after the template is rendered."""
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 import warnings
@@ -64,8 +65,14 @@ def main() -> None:
     )
 
     if "{{ cookiecutter.git_remote_url }}":
+        assert re.match(r"https://(?!.+\.git$)", "{{ cookiecutter.git_remote_url }}"), (
+            "The git remote url does not follow the form "
+            "`https://github.com/<user or organisation name>/<repo name>`. "
+            "I.e., a `https://`-link and without `.git` at the end. This is required "
+            "because it will be used in multiple places. Need not be github."
+        )
         subprocess.call(
-            ["git", "remote", "add", "origin", "{{ cookiecutter.git_remote_url }}"],
+            ["git", "remote", "add", "origin", "{{ cookiecutter.git_remote_url }}.git"],
         )
 
     if "{{ cookiecutter.make_initial_commit }}" == "yes":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ exclude = [
 
 [tool.ruff.per-file-ignores]
 "tests/*" = ["S101", "ANN", "D100", "D103"]
-"hooks/post_gen_project.py" = ["C901", "PLR0912", "T201"]
+"hooks/post_gen_project.py" = ["C901", "PLR0912", "S101", "T201"]
 "docs/source/conf.py" = ["DTZ005", "D100"]
 "docs/source/__init__.py" = ["D104"]
 "hooks/__init__.py" = ["D104"]
@@ -21,13 +21,11 @@ exclude = [
 [tool.ruff.pydocstyle]
 convention = "numpy"
 
-
 [tool.nbqa.config]
 black = "pyproject.toml"
 
 [tool.nbqa.mutate]
 black = 1
-
 
 [tool.pytest.ini_options]
 filterwarnings = []

--- a/tests/test_cookie.py
+++ b/tests/test_cookie.py
@@ -24,6 +24,22 @@ def test_invalid_python_version(cookies):
     assert str(result.exception).startswith("Hook script failed")
 
 
+def test_valid_non_empty_git_remote_url(cookies):
+    result = cookies.bake(extra_context={"git_remote_url": "https://a.b/x/y"})
+    assert result.exit_code == 0
+    assert result.exception is None
+
+
+def test_invalid_git_remote_url_not_https(cookies):
+    result = cookies.bake(extra_context={"git_remote_url": "ssh://a.b/x/y"})
+    assert result.exception is not None
+
+
+def test_invalid_git_remote_url_ends_with_git(cookies):
+    result = cookies.bake(extra_context={"git_remote_url": "https://a.b/x/y.git"})
+    assert result.exception is not None
+
+
 @pytest.mark.end_to_end()
 def test_bake_project(cookies):
     major, minor = sys.version_info[:2]

--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -2,8 +2,8 @@
 name = {{ cookiecutter.project_slug }}
 description = {{ cookiecutter.project_name }}
 long_description = file: README.md
-long_description_content_type = text/markdown
-url = https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
+long_description_content_type = text/markdown{% if cookiecutter.git_remote_url != '' %}
+url = {{ cookiecutter.git_remote_url }}{% endif %}
 author = {{ cookiecutter.author }}
 author_email = {{ cookiecutter.email }}
 license = {{ cookiecutter.open_source_license }}
@@ -16,12 +16,13 @@ classifiers =
     Operating System :: Microsoft :: Windows
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3 :: Only{% if cookiecutter.git_remote_url != '' %}
 project_urls =
-    Changelog = https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
-    Documentation = https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
-    Github = https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
-    Tracker = https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/issues
+    Changelog = {{ cookiecutter.git_remote_url }}
+    Documentation = {{ cookiecutter.git_remote_url }}
+    Github = {{ cookiecutter.git_remote_url }}
+    Tracker = {{ cookiecutter.git_remote_url }}/issues
+{% endif %}
 
 [options]
 packages = find:


### PR DESCRIPTION
- Was using different links in `setup.cfg`
- Now `git_remote_url` everywhere, must have the form `https://github.com/<user or organisation name>/<repo name>`
- Add assert statements and tests
- Explain in dialogue