### PR TITLE
Add no-commit-to-branch (main) pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,8 @@ repos:
         description: Forces to replace line ending by the UNIX 'lf' character.
       - id: name-tests-test
         args: [--pytest-test-first]
+      - id: no-commit-to-branch
+        args: [--branch, main]
       - id: trailing-whitespace
       - id: check-ast
       - id: check-docstring-first


### PR DESCRIPTION
Adds pre-commit hook that prevents committing to main.

This feature is important for template developers to avoid mistakenly committing to the main branch. However, we do not want this hook passed down to the template users.

### ToDo

- [ ] Add a section to the documentation to delete this hook when updating the template.
