### PR TITLE
Replace pdbpp by pdbp and update changes history

### DIFF
--- a/CHANGES_template.md
+++ b/CHANGES_template.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## v0.8.1 -- July 2024
+
+Display the correct version number in the rendered docs.
+
 ## v0.8.0 -- July 2024
 
 Complete re-write of how to obtain templates, simplifying the example project, and

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,6 @@ dependencies:
   - statsmodels
   - numpy
   - pandas >=2.2
-  - pdbpp
   - plotly >=5.2.0,<6
 
   # R template project dependencies
@@ -35,4 +34,4 @@ dependencies:
   - r-forcats
 
   # Install project
-  - pip: [-e ., kaleido]
+  - pip: [-e ., pdbp, kaleido]


### PR DESCRIPTION
Replaces pdbpp by pdbp and adds some ex-post additions to `CHANGES_template.md`

See [this](https://dev.to/mintzworld/the-new-pdbp-pdb-python-debugger-2blc) blogpost on why this is required.

Closes #157 