### PR TITLE
Fix codespell ignore

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,6 +72,6 @@ repos:
     rev: v2.4.1
     hooks:
       - id: codespell
-        exclude: pixi.lock
+        exclude: pixi\.lock|inst/WORDLIST
 ci:
   autoupdate_schedule: monthly

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,6 +72,6 @@ repos:
     rev: v2.4.1
     hooks:
       - id: codespell
-        exclude: pixi\.lock|inst/WORDLIST
+        exclude: pixi\.lock|inst/WORDLIST|ipynb
 ci:
   autoupdate_schedule: monthly

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,6 +72,6 @@ repos:
     rev: v2.4.1
     hooks:
       - id: codespell
-        exclude: pixi\.lock|inst/WORDLIST|ipynb
+        exclude: pixi.lock|inst/WORDLIST|ipynb
 ci:
   autoupdate_schedule: monthly

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,7 +179,3 @@ norecursedirs = ["docs"]
 [tool.yamlfix]
 line_length = 88
 none_representation = "null"
-
-
-[tool.codespell]
-skip = "*.ipynb,inst/WORDLIST"


### PR DESCRIPTION
Closes #173

I also checked for ipynb; specifying in toml did not work so I added it to the pre-commit config as well.

I removed the section in `pyproject.toml`. Upside is less room for confusion for future users, but I can only check this on Windows (maybe other platforms handle this differently?).