### PR TITLE
Backfill changelog for v0.12.0–v0.12.4

### DIFF
--- a/CHANGES_template.md
+++ b/CHANGES_template.md
@@ -1,6 +1,32 @@
 # Release Notes
 
 
+## v0.12.4 — July 2026
+
+- Type-check with `ty` as a pre-commit hook instead of a pixi task.
+- Refresh the environment (pixi 0.72, full lock update) and pre-commit hooks.
+- Update the `.ai-instructions` submodule.
+- Pin `nodejs < 26` to dodge a node-fetch/keep-alive regression that breaks the
+  docs build.
+
+## v0.12.3 — April 2026
+
+- Environment update.
+
+## v0.12.2 — March 2026
+
+- Update environment and fix inconsistencies.
+
+## v0.12.1 — February 2026
+
+- README: make clear that pytask is required to build the project.
+
+## v0.12.0 — January 2026
+
+- Switch pre-commit tooling to `prek`; simplify the docs and `pyproject.toml`.
+- Typing improvements; remove type checking from ruff.
+- View the paper in HTML format.
+
 ## v0.11 — December 2025
 
 - Remove LaTeX in favor of Jupyter Book / MyST and Slidev.


### PR DESCRIPTION
## Summary

The hand-maintained changelog (`CHANGES_template.md`, surfaced in the docs via
`release_notes.md`) had stopped at **v0.11 — December 2025**, so the published
docs advertised v0.11 as the latest release while **v0.12.0–v0.12.4** were out.

This backfills the missing entries from the tagged commits:

| Tag | PR |
| --- | --- |
| v0.12.0 (Jan 2026) | #185 (+ #183, #184) |
| v0.12.1 (Feb 2026) | #188 |
| v0.12.2 (Mar 2026) | #193 |
| v0.12.3 (Apr 2026) | #204 |
| v0.12.4 (Jul 2026) | #213 |

Changelog-only; no code or version changes. The package version is derived from
git tags via hatch-vcs, so nothing else needed updating — this just keeps the
human-readable release notes in sync. Not tied to the v0.12.4 release (which is
already tagged); it'll simply ride along in the next one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
