### PR TITLE
Ignore miktex.org in the docs link checker

### DIFF
--- a/docs_template/source/myst.yml
+++ b/docs_template/source/myst.yml
@@ -52,6 +52,7 @@ project:
       keys:
         - 'https://jupyterbook.org/**'
         - 'https://sli.dev/**'
+        - 'https://miktex.org/**'
         - 'https://www.computerhope.com/**'
         - 'https://www.stem.org.uk/**'
         - 'http://localhost:*/**'


### PR DESCRIPTION
## Summary

- The docs CI link-check step (`check-urls` → `jupyter book build --check-links --strict`)
  failed intermittently on `https://miktex.org/`, most recently on `main` right after
  merging #221 — even though the page loads fine (verified with `curl`, 200 OK, and
  reachable from this machine at the time of the failure).
- Most likely `miktex.org` rate-limits or blocks bot/CI traffic rather than the link
  actually being broken.
- Adds `https://miktex.org/**` to the existing `link-resolves` ignore list in
  `docs_template/source/myst.yml`, alongside the other domains already excluded there for
  the same reason (`jupyterbook.org`, `sli.dev`, `computerhope.com`, `stem.org.uk`).

## Test plan

- [x] `pixi run -e docs check-urls` — clean build, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)