### PR TITLE
Backfill changelog for v0.12.0-v0.12.5

### DIFF
--- a/CHANGES_template.md
+++ b/CHANGES_template.md
@@ -1,6 +1,42 @@
 # Release Notes
 
 
+## v0.12.5 — August 2026
+
+- Fix `pixi run pytask` failing on a fresh clone because `npx slidev` needs
+  `node_modules` (#220): add an `install-npm` pixi task that runs automatically
+  before `pytask` and `view-pres`.
+- Sync pre-commit hooks, GitHub Actions pins, and pixi task names (`docs` →
+  `build-docs`) with the latest boilerplate.
+- Update npm dependencies to their latest versions and eliminate all `npm audit`
+  findings.
+
+## v0.12.4 — July 2026
+
+- Type-check with `ty` as a pre-commit hook instead of a pixi task.
+- Refresh the environment (pixi 0.72, full lock update) and pre-commit hooks.
+- Update the `.ai-instructions` submodule.
+- Pin `nodejs < 26` to dodge a node-fetch/keep-alive regression that breaks the
+  docs build.
+
+## v0.12.3 — April 2026
+
+- Environment update.
+
+## v0.12.2 — March 2026
+
+- Update environment and fix inconsistencies.
+
+## v0.12.1 — February 2026
+
+- README: make clear that pytask is required to build the project.
+
+## v0.12.0 — January 2026
+
+- Switch pre-commit tooling to `prek`; simplify the docs and `pyproject.toml`.
+- Typing improvements; remove type checking from ruff.
+- View the paper in HTML format.
+
 ## v0.11 — December 2025
 
 - Remove LaTeX in favor of Jupyter Book / MyST and Slidev.


### PR DESCRIPTION
## Summary

- `CHANGES_template.md` stopped at v0.11 even though six releases have shipped since
  (v0.12.0 through the just-tagged v0.12.5).
- Reuses the content for v0.12.0-v0.12.4 from the previously-closed #214, cross-checked
  against the actual `git log` for each tag range to confirm accuracy (each bullet maps
  to a real commit; routine dependency-bump PRs are omitted, consistent with how the
  rest of the changelog already treats them).
- Adds a new v0.12.5 entry summarizing #221 (the `pixi run pytask` npm-install fix and
  boilerplate sync merged as the v0.12.5 tag).
- Does not include #222 (the miktex.org link-check ignore), since it landed after the
  v0.12.5 tag and isn't part of a release yet — it'll get picked up whenever the next
  version is tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)